### PR TITLE
Fix broken video-url for users with edit-permission on flowplayer-block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Drop Plone 4.2 support. [elioschmutz]
 - Fix broken video-url for users with edit-permission on flowplayer-block. [elioschmutz]
 - Drop Plone 4.1 support. [jone]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Fix broken video-url for users with edit-permission on flowplayer-block. [elioschmutz]
 - Drop Plone 4.1 support. [jone]
 
 

--- a/simplelayout/types/flowplayerblock/flowplayer.pt
+++ b/simplelayout/types/flowplayerblock/flowplayer.pt
@@ -14,7 +14,7 @@
          consider such text/image as a splash screen and does not display
          itself until clicked!
         </tal:comment>
-        <a style="width:100%;" tal:attributes="href string:${view/href}/download;
+        <a style="width:100%;" tal:attributes="href string:${view/href};
                            class python:audio and 'autoFlowPlayer audio' or 'autoFlowPlayer video'"></a>
     </div>
 

--- a/simplelayout/types/flowplayerblock/flowplayer.py
+++ b/simplelayout/types/flowplayerblock/flowplayer.py
@@ -3,3 +3,16 @@ from collective.flowplayer.browser.view import File
 
 class FlowPlayerBlock(File):
     """Block view for flowplayer enabled files"""
+
+    def href(self):
+        """Fixes an issue where a logged in user with edit permission was not
+        able to play the video due to a broken URL.
+
+        This happened if the ID of the file-object (context) did not included
+        the file-extension.
+        """
+        url = super(FlowPlayerBlock, self).href()
+        parts = url.split('?')
+        parts[0] = parts[0] + "/download"
+
+        return '?'.join(parts)

--- a/simplelayout/types/flowplayerblock/tests/test_flowplayerblock.py
+++ b/simplelayout/types/flowplayerblock/tests/test_flowplayerblock.py
@@ -51,3 +51,29 @@ class TestFlowplayerBlock(TestCase):
         self.file.setFile(dummy)
         self.assertIn('simplelayout-block-wrapper flowplayerblock',
                       view.index())
+
+    def test_href_returns_propper_url_if_file_id_has_extension_included(self):
+        view = queryMultiAdapter((self.file, self.file.REQUEST),
+                                 name="block_view-flowplayer")
+
+        self.file.id = "some.flv"
+        dummy = StringIO("data")
+        dummy.filename = "some.flv"
+        self.file.setFile(dummy)
+
+        self.assertEqual(
+            'http://nohost/plone/folder/some.flv/download',
+            view.href())
+
+    def test_href_returns_propper_url_if_file_id_has_no_extension_included(self):
+        view = queryMultiAdapter((self.file, self.file.REQUEST),
+                                 name="block_view-flowplayer")
+
+        self.file.id = "some"
+        dummy = StringIO("data")
+        dummy.filename = "some.flv"
+        self.file.setFile(dummy)
+
+        self.assertEqual(
+            'http://nohost/plone/folder/some/download?e=.flv',
+            view.href())

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-
-package-name = simplelayout.types.flowplayerblock


### PR DESCRIPTION
Before:
![screen1](https://user-images.githubusercontent.com/557005/54423427-ee9fa700-4710-11e9-9e18-1313f2e08d5a.gif)

After:
![screen2](https://user-images.githubusercontent.com/557005/54423426-ee9fa700-4710-11e9-8f98-01728fd30c0b.gif)

ℹ️ Das Video ist einfach schwarz. Das ist kein Fehler.

Issuer: https://extranet.4teamwork.ch/support/0141.03-support-intranetbern/tracker-intranetbern/487